### PR TITLE
Fix TypeError in get_max_udp_size by removing ASCII encoding

### DIFF
--- a/fuzzowski/helpers/helpers.py
+++ b/fuzzowski/helpers/helpers.py
@@ -136,7 +136,7 @@ def get_max_udp_size():
     if windows:
         sol_socket = ctypes.c_int(0xffff)
         sol_max_msg_size = 0x2003
-        lib = ctypes.WinDLL('Ws2_32.dll'.encode('ascii'))
+        lib = ctypes.WinDLL('Ws2_32.dll')
         opt = ctypes.c_int(sol_max_msg_size)
     elif linux or mac:
         if mac:


### PR DESCRIPTION
Resolve TypeError by removing ASCII encoding from ctypes.WinDLL call.
This request solves #32.